### PR TITLE
`udd-check`時にテストが実行されない問題を解消

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Deno Test
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   check:

--- a/.github/workflows/udd_check.yml
+++ b/.github/workflows/udd_check.yml
@@ -20,9 +20,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git remote set-url --push origin https://deno-depandabot[bot]:$GH_TOKEN@github.com/kakomimasu/server.git
+          git remote set-url --push origin https://kakomimasu:$GH_TOKEN@github.com/kakomimasu/server.git
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/udd_check.yml
+++ b/.github/workflows/udd_check.yml
@@ -20,7 +20,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          git remote set-url --push origin https://kakomimasu:$GH_TOKEN@github.com/kakomimasu/server.git
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git remote set-url --push origin https://deno-depandabot[bot]:$GH_TOKEN@github.com/kakomimasu/server.git
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/udd_check.yml
+++ b/.github/workflows/udd_check.yml
@@ -10,6 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Git config
         run: |
           git config --local user.email "action@github.com"
@@ -45,4 +51,4 @@ jobs:
         if: steps.diff.outputs.changes_exist == 'true'
         run: gh pr create --title "Update Deno Dependency" --body ""
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/udd_check.yml
+++ b/.github/workflows/udd_check.yml
@@ -17,8 +17,6 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Git config
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/udd_check.yml
+++ b/.github/workflows/udd_check.yml
@@ -20,9 +20,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git remote set-url --push origin https://deno-depandabot[bot]:$GH_TOKEN@github.com/kakomimasu/server.git
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/udd_check.yml
+++ b/.github/workflows/udd_check.yml
@@ -17,9 +17,12 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Git config
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          git remote set-url --push origin https://deno-depandabot[bot]:$GH_TOKEN@github.com/kakomimasu/server.git
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x


### PR DESCRIPTION
Github actions botが生成したcommitなどには別ワークフローが反応しないようになっているらしく、push時のみトリガーするテストは反応しなかった。
自分で作成したGithub app（deno-dependabot）であれば別ワークフローも反応するようになっているため、pull_request時にも実行するように`test.yml`を変更しました。