### PR TITLE
GIthub actionsのテストでFirebaseのエミュレータを使用するように変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,16 @@ jobs:
     with:
       config_file: deno.json
 
+  start-emulator:
+    needs: check
+    runs-on: ubuntu-latest
+    services:
+      firebase-emulator:
+        image: ghcr.io/kakomimasu/firebase-emulator:latest
+        ports:
+          - 8080:8080
+          - 9000:9000
+          - 9099:9099
   test:
     needs: check
     runs-on: ${{ matrix.os }}
@@ -25,8 +35,8 @@ jobs:
       - name: Run test
         if: ${{ runner.os == 'Windows' }}
         env:
-          FIREBASE_USERNAME: ${{secrets.FIREBASE_USERNAME}}
-          FIREBASE_PASSWORD: ${{secrets.FIREBASE_PASSWORD}}
+          FIREBASE_USERNAME: test@example.com
+          FIREBASE_PASSWORD: server-admin
           FIREBASE_TEST: true
         run: |
           deno run -A --location http://localhost server.ts > $null &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,7 @@ jobs:
     uses: kakomimasu/kakomimasu.github.io/.github/workflows/dfl-check.yml@main
     with:
       config_file: deno.json
-
-  start-emulator:
+  test:
     needs: check
     runs-on: ubuntu-latest
     services:
@@ -18,12 +17,6 @@ jobs:
           - 8080:8080
           - 9000:9000
           - 9099:9099
-  test:
-    needs: check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest,macos-latest,windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: denoland/setup-deno@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Run test
         if: ${{ runner.os != 'Windows' }}
         env:
-          FIREBASE_USERNAME: ${{secrets.FIREBASE_USERNAME}}
-          FIREBASE_PASSWORD: ${{secrets.FIREBASE_PASSWORD}}
+          FIREBASE_USERNAME: test@example.com
+          FIREBASE_PASSWORD: server-admin
           FIREBASE_TEST: true
         run: |
           deno run -A --location http://localhost server.ts > /dev/null &

--- a/deps.ts
+++ b/deps.ts
@@ -21,12 +21,14 @@ export { initializeApp } from "https://www.gstatic.com/firebasejs/9.1.3/firebase
 
 export {
   connectAuthEmulator,
+  createUserWithEmailAndPassword,
   getAuth,
   signInWithEmailAndPassword,
   signOut,
 } from "https://www.gstatic.com/firebasejs/9.1.3/firebase-auth.js";
 
 export {
+  connectDatabaseEmulator,
   get,
   getDatabase,
   ref,

--- a/v1/parts/firestore_opration.ts
+++ b/v1/parts/firestore_opration.ts
@@ -4,6 +4,8 @@ import { Tournament as ITournament } from "../types.ts";
 import { ExpGame } from "./expKakomimasu.ts";
 import { pathResolver } from "../util.ts";
 import {
+  connectAuthEmulator,
+  connectDatabaseEmulator,
   get,
   getAuth,
   getDatabase,
@@ -13,10 +15,14 @@ import {
   signInWithEmailAndPassword,
 } from "../../deps.ts";
 
+const isTest = Deno.env.get("FIREBASE_TEST") === "true";
+
 const setting = getSetting();
 const app = initializeApp(setting.conf);
 const auth = getAuth();
+isTest && connectAuthEmulator(auth, "http://localhost:9099", undefined);
 const db = getDatabase(app, setting.dbURL);
+isTest && connectDatabaseEmulator(db, "localhost", 9000);
 
 /** 管理ユーザでログイン */
 async function login() {
@@ -185,7 +191,7 @@ function getSetting() {
 
   let conf;
   let dbURL;
-  if (firebaseTest === "true") {
+  /*if (firebaseTest === "true") {
     conf = {
       apiKey: "AIzaSyCIzvSrMgYAV2SVIPbRMSaHWjsdLDk781A",
       authDomain: "kakomimasu-test.firebaseapp.com",
@@ -196,17 +202,18 @@ function getSetting() {
     };
     dbURL = "https://kakomimasu-test-default-rtdb.firebaseio.com/";
   } else {
-    conf = {
-      apiKey: "AIzaSyBOas3O1fmIrl51n7I_hC09YCG0EEe7tlc",
-      authDomain: "kakomimasu.firebaseapp.com",
-      projectId: "kakomimasu",
-      storageBucket: "kakomimasu.appspot.com",
-      messagingSenderId: "883142143351",
-      appId: "1:883142143351:web:dc6ddc1158aa54ada74572",
-      measurementId: "G-L43FT511YW",
-    };
-    dbURL = "https://kakomimasu-default-rtdb.firebaseio.com/";
-  }
+    */
+  conf = {
+    apiKey: "AIzaSyBOas3O1fmIrl51n7I_hC09YCG0EEe7tlc",
+    authDomain: "kakomimasu.firebaseapp.com",
+    projectId: "kakomimasu",
+    storageBucket: "kakomimasu.appspot.com",
+    messagingSenderId: "883142143351",
+    appId: "1:883142143351:web:dc6ddc1158aa54ada74572",
+    measurementId: "G-L43FT511YW",
+  };
+  dbURL = "https://kakomimasu-default-rtdb.firebaseio.com/";
+  //}
 
   return { conf, dbURL, username, password };
 }

--- a/v1/parts/firestore_opration.ts
+++ b/v1/parts/firestore_opration.ts
@@ -189,8 +189,8 @@ function getSetting() {
     password = Deno.env.get("FIREBASE_PASSWORD");
   }
 
-  let conf;
-  let dbURL;
+  //let conf;
+  //let dbURL;
   /*if (firebaseTest === "true") {
     conf = {
       apiKey: "AIzaSyCIzvSrMgYAV2SVIPbRMSaHWjsdLDk781A",
@@ -203,7 +203,7 @@ function getSetting() {
     dbURL = "https://kakomimasu-test-default-rtdb.firebaseio.com/";
   } else {
     */
-  conf = {
+  const conf = {
     apiKey: "AIzaSyBOas3O1fmIrl51n7I_hC09YCG0EEe7tlc",
     authDomain: "kakomimasu.firebaseapp.com",
     projectId: "kakomimasu",
@@ -212,7 +212,7 @@ function getSetting() {
     appId: "1:883142143351:web:dc6ddc1158aa54ada74572",
     measurementId: "G-L43FT511YW",
   };
-  dbURL = "https://kakomimasu-default-rtdb.firebaseio.com/";
+  const dbURL = "https://kakomimasu-default-rtdb.firebaseio.com/";
   //}
 
   return { conf, dbURL, username, password };


### PR DESCRIPTION
Fix #79 

FIREBASE_TEST：trueの時にも標準のconfigを返すように変更しました（エミュレータで使用するdbURLが変わってしまうため）
また、Dockerを使ってエミュレータを起動しているのでテストはUbuntuのみにしました。

エミュレータでは
FIREBASE_USERNAME：test@example.com
FIREBASE_PASSWORD：server-admin
を使用します。

エミュレータ自体は[firebase-emulator](https://github.com/kakomimasu/firebase-emulator)でDockerfileとPackageを作ってあります。

