### PR TITLE
fix(v1): DBに存在しないボード名を取得したときの処理を追加

### DIFF
--- a/v1/parts/firestore_opration.ts
+++ b/v1/parts/firestore_opration.ts
@@ -116,11 +116,14 @@ export async function getAllGames(): Promise<ExpGame[]> {
 }
 
 /** ボードを1つ取得 */
-export async function getBoard(id: string): Promise<Core.Board> {
+export async function getBoard(id: string): Promise<Core.Board | undefined> {
   const boardsRef = ref(db, "boards/" + id);
   const snap = await get(boardsRef);
-  const board = createBoard(snap.val());
-  return board;
+  const rawBoard = snap.val();
+  if (rawBoard) {
+    const board = createBoard(snap.val());
+    return board;
+  } else return undefined;
 }
 
 /** ボードをすべて取得 */

--- a/v1/test/game_test.js
+++ b/v1/test/game_test.js
@@ -41,7 +41,7 @@ const data = {
 
 // /v1/game/create Test
 // テスト項目
-// 正常、ボード名無し、ユーザ無し、既に登録済みのユーザ、playerIdentifiers無効
+// 正常、ボード名無し、存在しないボード名、ユーザ無し、既に登録済みのユーザ、playerIdentifiers無効
 // 存在しないトーナメントID
 // personal game通常、personal game auth invalid
 Deno.test("v1/game/create:normal", async () => {
@@ -84,6 +84,16 @@ Deno.test("v1/game/create:invalid boardName", async () => {
     const res = await ac.gameCreate({
       ...data,
       boardName: null,
+      option: { dryRun: true },
+    });
+    assertEquals(res.data, errors.INVALID_BOARD_NAME);
+  }
+});
+Deno.test("v1/game/create:not exist board", async () => {
+  {
+    const res = await ac.gameCreate({
+      ...data,
+      boardName: "existboard",
       option: { dryRun: true },
     });
     assertEquals(res.data, errors.INVALID_BOARD_NAME);


### PR DESCRIPTION
Fix #94 

`getBoard`内の`snap.val()`がnullだったことが原因