### PR TITLE
fix(env): firebase emulatorのホスト名を環境変数で設定するように変更

### DIFF
--- a/envconfig.yml
+++ b/envconfig.yml
@@ -8,6 +8,9 @@ DISCORD_WEBHOOK_URL: # 予期しないエラーが発生したときにDiscord�
 FIREBASE_TEST: # firebase emulatorを使うかどうか
   require: false
   default: false
+FIREBASE_EMULATOR_HOST:
+  require: false
+  default: "localhost"
 FIREBASE_USERNAME: # firebase の管理者ユーザ名
   require: true
 FIREBASE_PASSWORD: # firebase の管理者パスワード

--- a/v1/parts/firestore_opration.ts
+++ b/v1/parts/firestore_opration.ts
@@ -20,9 +20,10 @@ const isTest = reqEnv.FIREBASE_TEST;
 const setting = getSetting();
 const app = initializeApp(setting.conf);
 const auth = getAuth();
-isTest && connectAuthEmulator(auth, "http://localhost:9099", undefined);
+isTest &&
+  connectAuthEmulator(auth, "http://host.docker.internal:9099", undefined);
 const db = getDatabase(app, setting.dbURL);
-isTest && connectDatabaseEmulator(db, "localhost", 9000);
+isTest && connectDatabaseEmulator(db, "host.docker.internal", 9000);
 
 /** 管理ユーザでログイン */
 async function login() {

--- a/v1/parts/firestore_opration.ts
+++ b/v1/parts/firestore_opration.ts
@@ -21,9 +21,13 @@ const setting = getSetting();
 const app = initializeApp(setting.conf);
 const auth = getAuth();
 isTest &&
-  connectAuthEmulator(auth, "http://host.docker.internal:9099", undefined);
+  connectAuthEmulator(
+    auth,
+    `http://${reqEnv.FIREBASE_EMULATOR_HOST}:9099`,
+    undefined,
+  );
 const db = getDatabase(app, setting.dbURL);
-isTest && connectDatabaseEmulator(db, "host.docker.internal", 9000);
+isTest && connectDatabaseEmulator(db, reqEnv.FIREBASE_EMULATOR_HOST, 9000);
 
 /** 管理ユーザでログイン */
 async function login() {


### PR DESCRIPTION
docker-composeでemulator、server、viewerを統合させたものを作ろうと思った時にホスト名の指定が必要だったので変更しました。