### PR TITLE
OpenAPI 3.1への対応とAPIのバージョンごとのパスの修正

### DIFF
--- a/miyakonojo/parts/openapi.ts
+++ b/miyakonojo/parts/openapi.ts
@@ -3,7 +3,7 @@ import { OpenAPIValidator } from "../../util/openapi-validator.ts";
 
 export const openapi = {
   // export const openapi: OpenAPIObject = {
-  openapi: "3.0.0",
+  openapi: "3.1.1",
   info: {
     description: "",
     title: "囲みマス API",

--- a/miyakonojo/parts/openapi.ts
+++ b/miyakonojo/parts/openapi.ts
@@ -583,7 +583,7 @@ export const openapi = {
   },
   servers: [
     {
-      url: "//api.kakomimasu.com",
+      url: "//api.kakomimasu.com/miyakonojo",
     },
   ],
   components: {

--- a/miyakonojo/parts/openapi.ts
+++ b/miyakonojo/parts/openapi.ts
@@ -1,4 +1,4 @@
-// import { OpenAPIObject } from "openapi3-ts/oas30";
+// import { OpenAPIObject } from "openapi3-ts/oas31";
 import { OpenAPIValidator } from "../../util/openapi-validator.ts";
 
 export const openapi = {

--- a/tomakomai/parts/openapi.ts
+++ b/tomakomai/parts/openapi.ts
@@ -3,7 +3,7 @@ import { OpenAPIValidator } from "../../util/openapi-validator.ts";
 
 export const openapi = {
   // export const openapi: OpenAPIObject = {
-  openapi: "3.0.0",
+  openapi: "3.1.1",
   info: {
     title: "囲みマス API",
     version: "苫小牧",

--- a/tomakomai/parts/openapi.ts
+++ b/tomakomai/parts/openapi.ts
@@ -1,4 +1,4 @@
-// import { OpenAPIObject } from "openapi3-ts/oas30";
+// import { OpenAPIObject } from "openapi3-ts/oas31";
 import { OpenAPIValidator } from "../../util/openapi-validator.ts";
 
 export const openapi = {

--- a/tomakomai/parts/openapi.ts
+++ b/tomakomai/parts/openapi.ts
@@ -11,7 +11,7 @@ export const openapi = {
   },
   servers: [
     {
-      url: "https://api.kakomimasu.com",
+      url: "https://api.kakomimasu.com/tomakomai",
     },
   ],
   paths: {

--- a/util/openapi-validator.ts
+++ b/util/openapi-validator.ts
@@ -151,7 +151,6 @@ export class OpenAPIValidator<Base> {
     const schema = this.spreadSchema(schema_);
     // console.log(data, schema);
     // console.log(JSON.stringify(schema, null, 2));
-    if (schema.nullable && data === null) return true;
 
     // console.log("validate", typeof schema.type);
     if (typeof schema.type === "string") {

--- a/util/openapi-validator.ts
+++ b/util/openapi-validator.ts
@@ -90,7 +90,7 @@ export class OpenAPIValidator<Base> {
     contentType: ContentType,
   ): data is ResponseType<Path, Method, StatusCode, ContentType, Base> {
     const rawSchema = this.spreadResponse(
-      this.openapi.paths[path][method]
+      this.openapi.paths?.[path]?.[method]
         .responses[String(statusCode)],
     ).content?.[contentType].schema;
 
@@ -126,7 +126,7 @@ export class OpenAPIValidator<Base> {
     contentType: ContentType,
   ): data is RequestBodyType<Path, Method, ContentType, Base> {
     const rawSchema = this.spreadRequestBody(
-      this.openapi.paths[path][method]
+      this.openapi.paths?.[path]?.[method]
         .requestBody,
     ).content?.[contentType].schema;
 

--- a/util/openapi-validator.ts
+++ b/util/openapi-validator.ts
@@ -4,7 +4,7 @@ import {
   RequestBodyObject,
   ResponseObject,
   SchemaObject,
-} from "openapi3-ts/oas30";
+} from "openapi3-ts/oas31";
 import {
   InferReferenceType,
   Methods,

--- a/v1/parts/openapi.ts
+++ b/v1/parts/openapi.ts
@@ -1060,9 +1060,12 @@ export const openapi = {
             },
           },
           startedAtUnixTime: {
-            type: "integer",
             description: "ゲーム開始時刻(UNIX時間)",
-            nullable: true,
+            oneOf: [{
+              type: "integer",
+            }, {
+              type: "null",
+            }],
           },
           field: {
             description: "フィールド情報<br>開始前は非公開(`null`)です。",
@@ -1107,10 +1110,13 @@ export const openapi = {
                         enum: [0, 1],
                       },
                       player: {
-                        type: "integer",
-                        nullable: true,
                         description:
                           "マスを所持するプレイヤー番号(`players`の配列番号)。<br>`null`の場合は空白マス。",
+                        oneOf: [{
+                          type: "integer",
+                        }, {
+                          type: "null",
+                        }],
                       },
                     },
                   },

--- a/v1/parts/openapi.ts
+++ b/v1/parts/openapi.ts
@@ -1,4 +1,4 @@
-// import { OpenAPIObject } from "openapi3-ts/oas30";
+// import { OpenAPIObject } from "openapi3-ts/oas31";
 import { OpenAPIValidator } from "../../util/openapi-validator.ts";
 
 export const openapi = {

--- a/v1/parts/openapi.ts
+++ b/v1/parts/openapi.ts
@@ -8,6 +8,12 @@ export const openapi = {
     title: "Kakomimasu API",
     version: "0.1.0",
   },
+  servers: [
+    {
+      url: "/v1",
+      description: "Version 1 API",
+    },
+  ],
   paths: {
     "/matches/{gameId}/players": {
       post: {

--- a/v1/parts/openapi.ts
+++ b/v1/parts/openapi.ts
@@ -782,17 +782,6 @@ export const openapi = {
         summary: "ユーザ削除",
         tags: ["Users API"],
         security: [{ Bearer: [], Cookie: [] }],
-        parameters: [
-          {
-            in: "path",
-            name: "userIdOrName",
-            required: true,
-            schema: {
-              type: "string",
-              description: "ユーザID or ユーザネーム",
-            },
-          },
-        ],
         requestBody: {
           content: {
             "application/json": {


### PR DESCRIPTION
ローカルの http://0.0.0.0:8880/v1/openapi.json の生成結果を [Swagger Editor Next (beta)](https://editor-next.swagger.io/) に入れて、正常に表示されていることを確認しました
