### PR TITLE
👍 /v1/matches/stream API のゲーム取得個数をデフォルト20、最大50に設定

### DIFF
--- a/core/error.ts
+++ b/core/error.ts
@@ -46,6 +46,10 @@ export const errors = {
     errorCode: 105,
     message: "during the transition step",
   },
+  INVALID_STREAM_QUERY: {
+    errorCode: 106,
+    message: "invalid query parameter",
+  },
   INVALID_SCREEN_NAME: {
     errorCode: 201,
     message: "invalid screenName",

--- a/v1/gameStream.ts
+++ b/v1/gameStream.ts
@@ -3,6 +3,7 @@ import { SSEStreamingApi, streamSSE } from "@hono/hono/streaming";
 
 import { ResponseType } from "../util/openapi-type.ts";
 
+import { errors, ServerError } from "../core/error.ts";
 import { auth } from "./middleware.ts";
 import { openapi } from "./parts/openapi.ts";
 import { games } from "../core/datas.ts";
@@ -126,10 +127,14 @@ router.get(
 
     const q = params.get("q") ?? "";
     const sIdxStr = params.get("startIndex");
-    const sIdx = sIdxStr ? parseInt(sIdxStr) : undefined;
+    const sIdx = sIdxStr ? parseInt(sIdxStr) : 0;
     const eIdxStr = params.get("endIndex");
-    const eIdx = eIdxStr ? parseInt(eIdxStr) : undefined;
+    const eIdx = eIdxStr ? parseInt(eIdxStr) : sIdx + 20; // 指定がなければ 20 件
     const allowNewGame = params.get("allowNewGame") === "true";
+
+    if (eIdx - sIdx > 50) {
+      throw new ServerError(errors.INVALID_STREAM_QUERY);
+    }
 
     const searchOptions = analyzeStringSearchOption(q);
 


### PR DESCRIPTION
Fix #258 

/v1/matches/stream API のゲーム取得個数をデフォルト20、最大50に設定しました。

50個以上取得しようとするとエラーになるようになっています。

これでゲーム詳細画面の左カラムの開くのが重い問題が解決しそうです🙇