### PR TITLE
🎉 無人対戦の実装を追加

### DIFF
--- a/core/error.ts
+++ b/core/error.ts
@@ -50,6 +50,14 @@ export const errors = {
     errorCode: 106,
     message: "invalid query parameter",
   },
+  NOT_OPPONENT_CODE: {
+    errorCode: 107,
+    message: "can not find opponent code",
+  },
+  CAN_NOT_CREATE_GAME: {
+    errorCode: 108,
+    message: "can not create game",
+  },
   INVALID_SCREEN_NAME: {
     errorCode: 201,
     message: "invalid screenName",

--- a/core/kv.ts
+++ b/core/kv.ts
@@ -13,6 +13,7 @@ const BOARD_KEY = "boards";
 const TOURNAMENT_KEY = "tournaments";
 const USERS_KEY = "users";
 const GAMES_KEY = "games";
+const CODES_KEY = "codes";
 
 export interface KvUser {
   screenName: string;
@@ -30,6 +31,12 @@ export interface KvTournament {
   remarks: string;
   users: string[];
   gameIds: string[];
+}
+
+export interface KvCode {
+  type: string;
+  entryPoint: string;
+  files: { [key: string]: string };
 }
 
 /** 全ユーザ保存 */
@@ -128,4 +135,34 @@ export async function getBoards(): Promise<Board[]> {
 /** ボード保存(JSONから) */
 export async function setBoard(board: Board): Promise<void> {
   await kv.set([BOARD_KEY, board.name], board);
+}
+
+/** コード保存 */
+export async function setCode(
+  userId: string,
+  codeId: string,
+  code: KvCode,
+): Promise<void> {
+  await kv.set([CODES_KEY, userId, codeId], await compression(code));
+
+  // 不要にデータが増えないように以前のコードを削除
+  const prevData = kv.list({ prefix: [CODES_KEY, userId] });
+  for await (const d of prevData) {
+    if (d.key[2] !== codeId) {
+      await kv.delete(d.key);
+    }
+  }
+}
+
+/** コード取得 */
+export async function getCodes(
+  userId: string,
+) {
+  const data = kv.list<ArrayBuffer>({ prefix: [CODES_KEY, userId] });
+
+  const codes: KvCode[] = [];
+  for await (const d of data) {
+    codes.push(await decompression(d.value));
+  }
+  return codes;
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,6 +9,7 @@
   },
   "lock": false,
   "imports": {
+    "@deno/sandbox": "jsr:@deno/sandbox@^0.13.2",
     "@hono/hono": "jsr:@hono/hono@^4.6.17",
     "@octokit/rest": "npm:@octokit/rest@^22.0.1",
     "@std/assert": "jsr:@std/assert@^1.0.6",

--- a/env.config.ts
+++ b/env.config.ts
@@ -24,6 +24,12 @@ export const config = {
     require: false,
     default: "",
   },
+  DENO_DEPLOY_TOKEN: {
+    require: false,
+  },
+  MUJIN_MATCH_API_HOST: {
+    require: false,
+  },
   TEST: {
     require: false,
     default: "false",

--- a/v1/_matches.ts
+++ b/v1/_matches.ts
@@ -1,10 +1,12 @@
 import { Hono } from "@hono/hono";
+import { Sandbox } from "@deno/sandbox";
+
 import * as Core from "kkmm-core";
 
 import { nowUnixTime } from "../core/util.ts";
 import { accounts, games, tournaments } from "../core/datas.ts";
 import { errors, ServerError } from "../core/error.ts";
-import { getBoard, getBoards } from "../core/kv.ts";
+import { getBoard, getBoards, getCodes } from "../core/kv.ts";
 import { ExpGame, GameInit, Player } from "../core/expKakomimasu.ts";
 import { env } from "../core/env.ts";
 import { ResponseType, SchemaType } from "../util/openapi-type.ts";
@@ -351,6 +353,98 @@ router.post(
       const aiPlayer = new Player(ai.name, "");
       game.ai = aiClient;
       game.attachPlayer(aiPlayer);
+    }
+
+    const { gameId, ...rawRes } = player.getJSON();
+    const res: AiMatchRes = {
+      ...rawRes,
+      gameId: gameId ?? crypto.randomUUID(),
+    }; // dry-run用にgameIdを設定
+    return ctx.json(res);
+  },
+);
+
+router.post(
+  "/mujin/players",
+  contentTypeFilter("application/json"),
+  auth({ bearer: true, required: false }),
+  jsonParse(),
+  async (ctx) => {
+    const reqData = ctx.get("data");
+    const isValid = validator.validateRequestBody(
+      reqData,
+      "/matches/mujin/players",
+      "post",
+      "application/json",
+    );
+    if (!isValid) {
+      throw new ServerError(errors.INVALID_REQUEST);
+    }
+
+    const authedUserId = ctx.get("authed_userId") as string;
+    const opponentId = reqData.opponentId;
+
+    const opponentUser = accounts.findById(opponentId);
+    if (!opponentUser) throw new ServerError(errors.NOT_USER);
+    const opponentCode = (await getCodes(opponentId))[0];
+    if (!opponentCode) {
+      throw new ServerError(errors.NOT_OPPONENT_CODE);
+    }
+
+    const player = createPlayer(authedUserId, reqData);
+
+    const bname = reqData.boardName || boardname;
+    const brd = bname ? await getBoard(bname) : await getRandomBoard(); //readBoard(bname);
+    if (!brd) throw new ServerError(errors.INVALID_BOARD_NAME);
+    if (!reqData.dryRun) {
+      const init: GameInit = brd;
+
+      // オプション適用
+      if (reqData.nAgent) init.nAgent = reqData.nAgent;
+      if (reqData.totalTurn) init.totalTurn = reqData.totalTurn;
+      if (reqData.operationSec) init.operationSec = reqData.operationSec;
+      if (reqData.transitionSec) init.transitionSec = reqData.transitionSec;
+
+      const vsMatchApiHost = env.MUJIN_MATCH_API_HOST;
+      if (!vsMatchApiHost) {
+        // サーバ側の指定ミスなのでただのエラーにする
+        throw new Error("MUJIN_MATCH_API_HOST env is required for vs match");
+      }
+
+      // Sandboxの作成
+      await using sandbox = await Sandbox.create({ timeout: "15m" }).catch(
+        (e) => {
+          console.error("Failed to create sandbox:", e);
+          throw new ServerError(errors.CAN_NOT_CREATE_GAME);
+        },
+      );
+
+      const game = new ExpGame(init);
+      games.push(game);
+      if (player.type === "account") {
+        const user = accounts.getUsers().find((user) =>
+          user.id === authedUserId
+        );
+
+        game.name =
+          `対AI戦：${user?.screenName}(@${user?.name}) vs ${opponentUser.screenName}(@${opponentUser.name})`;
+      } else {
+        game.name =
+          `対AI戦：${player.id} vs ${opponentUser.screenName}(@${opponentUser.name})`;
+      }
+      game.attachPlayer(player);
+
+      for (const [path, content] of Object.entries(opponentCode.files)) {
+        await sandbox.fs.writeTextFile(path, content);
+      }
+
+      sandbox.env.set("BEARER_TOKEN", opponentUser.bearerToken);
+      sandbox.env.set("GAME_ID", game.id);
+      sandbox.env.set("API_HOST", vsMatchApiHost);
+
+      await sandbox.spawn("deno", {
+        args: ["run", "-A", opponentCode.entryPoint],
+      });
     }
 
     const { gameId, ...rawRes } = player.getJSON();

--- a/v1/_users.ts
+++ b/v1/_users.ts
@@ -3,7 +3,7 @@ import { Hono } from "@hono/hono";
 import { contentTypeFilter, jsonParse } from "./util.ts";
 import { errors, ServerError } from "../core/error.ts";
 import { env } from "../core/env.ts";
-import { deleteUser, kv } from "../core/kv.ts";
+import { deleteUser, getCodes, kv, setCode } from "../core/kv.ts";
 import { auth } from "./middleware.ts";
 import { accounts, User } from "../core/datas.ts";
 import { ResponseType } from "../util/openapi-type.ts";
@@ -85,6 +85,26 @@ router.get(
     return ctx.json(body);
   },
 );
+
+router.post("/me/codes", auth({ cookie: true }), async (ctx) => {
+  const authedUserId = ctx.get("authed_userId");
+
+  const body = await ctx.req.json();
+
+  const codeId = crypto.randomUUID();
+  setCode(authedUserId, codeId, body);
+
+  return ctx.json({ status: "ok" });
+});
+
+router.get("/me/codes", auth({ cookie: true }), async (ctx) => {
+  const authedUserId = ctx.get("authed_userId");
+
+  const codes = await getCodes(authedUserId);
+  const codesData = Array.from(codes);
+
+  return ctx.json(codesData);
+});
 
 // ユーザ情報取得
 router.get(

--- a/v1/parts/openapi.ts
+++ b/v1/parts/openapi.ts
@@ -150,6 +150,72 @@ export const openapi = {
         },
       },
     },
+    "/matches/mujin/players": {
+      post: {
+        operationId: "joinMujinMatch",
+        description:
+          "無人対戦（投稿されたコードと対戦）するゲームに参加できます。<br>なお、プレイヤー数は2で固定になります。<br>`guestName`を指定してゲスト参加する場合、認証情報は要りません。",
+        summary: "ゲーム参加(無人対戦)",
+        tags: ["Matches API"],
+        security: [{}, { "Bearer": [] }],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                allOf: [
+                  {
+                    allOf: [{
+                      "$ref": "#/components/schemas/MatchesRequestBase",
+                    }, {
+                      type: "object",
+                      required: ["opponentId"],
+                      properties: {
+                        opponentId: {
+                          type: "string",
+                        },
+                        boardName: {
+                          type: "string",
+                        },
+                        nAgent: {
+                          type: "integer",
+                          description: "エージェント数",
+                        },
+                        totalTurn: {
+                          type: "integer",
+                          description: "ターン数",
+                        },
+                        operationSec: {
+                          type: "integer",
+                          description: "行動ステップ時間(秒)",
+                        },
+                        transitionSec: {
+                          type: "integer",
+                          description: "遷移ステップ時間(秒)",
+                        },
+                      },
+                      example: {
+                        opponentId: "123456",
+                        boardName: "A-1",
+                      },
+                    }],
+                  },
+                  { "$ref": "#/components/schemas/DryRunRequest" },
+                ],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            "$ref": "#/components/responses/MatchesJoin",
+          },
+          "400": {
+            "$ref": "#/components/responses/400",
+          },
+        },
+      },
+    },
+
     "/matches/{gameId}": {
       get: {
         operationId: "getMatch",

--- a/v1/test/users_test.js
+++ b/v1/test/users_test.js
@@ -292,3 +292,98 @@ Deno.test({
     });
   },
 });
+
+// POST /v1/users/me/codes Test
+// テスト項目
+// 正常（Cookie）・認証なし
+Deno.test({
+  name: "POST /v1/users/me/codes:normal by cookie",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await useUser(async (_user, sessionId) => {
+      const code = {
+        type: "playground",
+        entryPoint: "main.js",
+        files: { "main.js": "console.log('hello');" },
+      };
+      const res = await app.request("/v1/users/me/codes", {
+        method: "POST",
+        headers: {
+          Cookie: `site-session=${sessionId}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(code),
+      });
+      assert(res.ok);
+      const data = await res.json();
+      assertEquals(data, { status: "ok" });
+    });
+  },
+});
+Deno.test({
+  name: "POST /v1/users/me/codes:unauthorized",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const code = {
+      type: "playground",
+      entryPoint: "main.js",
+      files: { "main.js": "console.log('hello');" },
+    };
+    const res = await app.request("/v1/users/me/codes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(code),
+    });
+    assertEquals(res.status, 401);
+    const data = await res.json();
+    assertEquals(data, errors.UNAUTHORIZED);
+  },
+});
+
+// GET /v1/users/me/codes Test
+// テスト項目
+// 正常（Cookie）・認証なし
+Deno.test({
+  name: "GET /v1/users/me/codes:normal by cookie",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await useUser(async (_user, sessionId) => {
+      const code = {
+        type: "playground",
+        entryPoint: "main.js",
+        files: { "main.js": "console.log('hello');" },
+      };
+      // コードを登録してから取得
+      await app.request("/v1/users/me/codes", {
+        method: "POST",
+        headers: {
+          Cookie: `site-session=${sessionId}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(code),
+      });
+      const res = await app.request("/v1/users/me/codes", {
+        headers: { Cookie: `site-session=${sessionId}` },
+      });
+      assert(res.ok);
+      const data = await res.json();
+      assert(Array.isArray(data));
+      assertEquals(data.length, 1);
+      assertEquals(data[0], code);
+    });
+  },
+});
+Deno.test({
+  name: "GET /v1/users/me/codes:unauthorized",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const res = await app.request("/v1/users/me/codes");
+    assertEquals(res.status, 401);
+    const data = await res.json();
+    assertEquals(data, errors.UNAUTHORIZED);
+  },
+});


### PR DESCRIPTION
## 主な変更点

- 無人対戦に参加する API `POST /v1/mujin/players` を追加
  - opponentId を指定することで相手がいなくても対戦可能
  - その他のパラメータは大方 AI 対戦等と一緒
- 無人対戦に使うコードを保存する API `GET /v1/me/codes` と `POST /v1/me/codes` を追加
  - KV に保存します
