### PR TITLE
💚 CIでのツールインストールをmise-action使用するように変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.7.4
+      - uses: jdx/mise-action@v4
       - name: Run fmt
         run: deno fmt --check
       - name: Run lint
@@ -25,9 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.7.4
+      - uses: jdx/mise-action@v4
       - name: Run test
         run: |
           deno task test


### PR DESCRIPTION
https://github.com/jdx/mise-action

mise.toml が配置されていてバージョン固定もそちらを参照してくれるので mise-actions を使うように変更しました