### PR TITLE
💚 Dockerfile ビルド時に prisma generate するように & prisma 7.7 に固定変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ EXPOSE $PORT
 WORKDIR /home/kkmm-server
 COPY . .
 
+RUN deno task prisma:generate
+
 RUN deno task cache
 
 CMD deno task start

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,16 +7,15 @@
     "coverage": "deno coverage coverage --lcov --output=coverage/coverage.lcov",
     "coverage:report": "deno coverage coverage --html",
     "db:init": "deno run -A --unstable-kv db/init.ts",
-    "prisma:generate": "deno run -A npm:prisma generate",
-    "prisma:push": "deno run -A --env=.env npm:prisma db push",
-    "prisma:dev": "npx prisma@7.8.0 dev",
-    "prisma:studio": "npx prisma@7.8.0 studio --url='postgres://postgres:postgres@localhost:51214/template1?sslmode=disable&connection_limit=10&connect_timeout=0&max_idle_connection_lifetime=0&pool_timeout=0&socket_timeout=0'"
+    "prisma:generate": "deno run -A npm:prisma@7.7.0 generate",
+    "prisma:push": "deno run -A --env=.env npm:prisma@7.7.0 db push",
+    "prisma:dev": "npx prisma@7.7.0 dev",
+    "prisma:studio": "npx prisma@7.7.0 studio --url='postgres://postgres:postgres@localhost:51214/template1?sslmode=disable&connection_limit=10&connect_timeout=0&max_idle_connection_lifetime=0&pool_timeout=0&socket_timeout=0'"
   },
-  "lock": false,
   "imports": {
     "@hono/hono": "jsr:@hono/hono@^4.6.17",
-    "@prisma/adapter-pg": "npm:@prisma/adapter-pg@^7.0.0",
-    "@prisma/client": "npm:@prisma/client@^7.0.0",
+    "@prisma/adapter-pg": "npm:@prisma/adapter-pg@7.7.0",
+    "@prisma/client": "npm:@prisma/client@7.7.0",
     "@octokit/rest": "npm:@octokit/rest@^22.0.1",
     "@std/assert": "jsr:@std/assert@^1.0.6",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.2",
@@ -28,6 +27,6 @@
     "kkmm-core": "https://cdn.jsdelivr.net/gh/codeforkosen/Kakomimasu@v2.0.1/mod.ts",
     "kv_oauth": "jsr:@deno/kv-oauth@^0.11.0",
     "openapi3-ts": "npm:openapi3-ts@4.4.0",
-    "prisma": "npm:prisma@^7.0.0"
+    "prisma": "npm:prisma@7.7.0"
   }
 }


### PR DESCRIPTION
prisma クライアントを生成しないといけなかったため、Dockerfile に追加

また、起動時に512MB以上メモリを使ってしまってビルド失敗していたので、prisma のバージョンを明示的に指定&固定するように変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルド時にデータベース関連の生成処理が自動で実行されるようになり、環境差による不整合を減らしました。
  * 関連ツールのバージョンを統一し、開発・ビルド時の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->