### PR TITLE
Add manual Render deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy to Render
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the v prefix (for example, 1.2.3)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy and release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow can only deploy the main branch (got ${{ github.ref }})." >&2
+          exit 1
+
+      - name: Install Render CLI
+        run: |
+          curl -L https://github.com/render-oss/cli/releases/download/v2.22.0/cli_2.22.0_linux_amd64.zip -o render.zip
+          unzip render.zip
+          sudo mv cli_v2.22.0 /usr/local/bin/render
+
+      - name: Deploy to Render
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          CI: true
+        run: |
+          render deploys create "${{ secrets.RENDER_SERVICE_ID }}" \
+            --commit "${{ github.sha }}" \
+            --wait \
+            --output json \
+            --confirm
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --target "${{ github.sha }}" \
+            --title "v${{ inputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
Render への手動デプロイと、デプロイ成功後の GitHub Release 作成を自動化します。

## 変更内容

- `workflow_dispatch` でバージョンを入力して手動実行
- Render CLI v2.22.0 で `main` のコミットをデプロイ
- Render のデプロイ完了を待機し、成功時のみ Release を作成
- `main` 以外のブランチから実行された場合はデプロイ前に失敗
- `--generate-notes` でリリースノートを自動生成

必要な Repository Secrets: （すでに設定済みです）

- `RENDER_API_KEY`
- `RENDER_SERVICE_ID`

Render 側の設定で自動デプロイも停止しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 手動実行で指定したバージョンを使い、main ブランチのコミットをデプロイして GitHub Release を作成できるようになりました。
  * main ブランチ以外からの実行は失敗するようになり、デプロイ先への反映完了まで待機してから次の処理に進みます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->