### PR TITLE
📚 READMEのリンク切れの修正とローカル開発方法の追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,29 @@ https://api.kakomimasu.com
 
 ## 開発者向け
 
+### DB準備
+
+開発にはPostgreSQLが動作するサーバが必要です。
+
+ローカル用のPostgresサーバーを別途用意しない場合は、Prismaによるローカル用のPostgresサーバを使用すると手軽に用意できます。
+
+```
+deno task prisma:dev
+```
+
+PostgreSQLサーバを用意したら `.env` ファイルを作成し、 `DATABASE_URL`
+を設定します。
+
+`deno task prisma:dev`
+を実行した場合はコンソールに接続文字列が出力されるのでそれをコピーし、下記のように設定します。
+
+```
+DATABASE_URL="postgres://postgres:postgres@localhost:51214/template1?sslmode=disable&connection_limit=10&connect_timeout=0&max_idle_connection_lifetime=0&pool_timeout=0&socket_timeout=0"
+```
+
 ### サーバ起動
+
+DATABASE_URLの設定後、以下を実行します。
 
 ```console
 deno task prisma:generate

--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ https://api.kakomimasu.com
 | GITHUB_CLIENT_SECRET | GitHub OAuthログイン用<br>詳細は[こちら](https://deno.land/x/deno_kv_oauth)を参照 |            |
 | TEST                 | テスト時のフラグ                                                                  | `true`     |
 
-※
-`.env`ファイルが使用できます。([dotenv](https://deno.land/std/dotenv/mod.ts))<br>
-※
-`GITHUB_CLIENT_*`が未指定の場合、アカウントに関連する機能（BearerTokenを用いたAPI）は利用できません。ゲストモードによるゲーム参加は可能です。
+※ `.env`ファイルが使用できます。\
+※`GITHUB_CLIENT_*`が未指定の場合、アカウントに関連する機能（BearerTokenを用いたAPI）は利用できません。ゲストモードによるゲーム参加は可能です。
 
 ## 開発者向け
 


### PR DESCRIPTION
Resolves #278 

* リンク切れのURLを削除・修正
* .envファイルにDATABASE_URLの設定が必要なことを追記


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 環境変数の設定方法と、`.env`の利用可否を分かりやすく整理しました。
  * GitHub OAuth未設定時の利用制限を追記しました。
  * PostgreSQLの準備、ローカル環境構築、`DATABASE_URL`の設定手順を追加しました。
  * 公開フィールドへのリンクをアーカイブURLに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->